### PR TITLE
fix download of epsonscan2 source files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ if(NOT ${CURRENT_EPSONSHA1} STREQUAL ${ESPONSHA1})
   message(" ${EPSONFILENAME} does not exist or has invalid sha1, downloading")
   file(DOWNLOAD
     https://support.epson.net/linux/src/scanner/epsonscan2/${EPSONFILENAME}
+    HTTPHEADER "User-Agent: Mozilla/5.0"
     ${CMAKE_CURRENT_BINARY_DIR}/${EPSONFILENAME}
     SHOW_PROGRESS
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(NOT ${CURRENT_EPSONSHA1} STREQUAL ${ESPONSHA1})
   message(" ${EPSONFILENAME} does not exist or has invalid sha1, downloading")
   file(DOWNLOAD
     https://support.epson.net/linux/src/scanner/epsonscan2/${EPSONFILENAME}
-    HTTPHEADER "User-Agent: Mozilla/5.0"
+    HTTPHEADER "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
     ${CMAKE_CURRENT_BINARY_DIR}/${EPSONFILENAME}
     SHOW_PROGRESS
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(NOT ${CURRENT_EPSONSHA1} STREQUAL ${ESPONSHA1})
   message(" ${EPSONFILENAME} does not exist or has invalid sha1, downloading")
   file(DOWNLOAD
     https://support.epson.net/linux/src/scanner/epsonscan2/${EPSONFILENAME}
-    HTTPHEADER "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+    HTTPHEADER "User-Agent: Mozilla/5.0"
     ${CMAKE_CURRENT_BINARY_DIR}/${EPSONFILENAME}
     SHOW_PROGRESS
     LOG DOWNLOAD_LOG

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.12.2)
+cmake_minimum_required (VERSION 3.7)
 project (es2button)
 set(CMAKE_INSTALL_PREFIX "/usr")
 set(CMAKE_PROJECT_VERSION_MAJOR 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(NOT ${CURRENT_EPSONSHA1} STREQUAL ${ESPONSHA1})
   message(" ${EPSONFILENAME} does not exist or has invalid sha1, downloading")
   file(DOWNLOAD
     https://support.epson.net/linux/src/scanner/epsonscan2/${EPSONFILENAME}
-    HTTPHEADER "User-Agent: Mozilla/5.0"
+    HTTPHEADER "User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:58.0) Gecko/20100101 Firefox/58.0"
     ${CMAKE_CURRENT_BINARY_DIR}/${EPSONFILENAME}
     SHOW_PROGRESS
     LOG DOWNLOAD_LOG

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,9 @@ if(NOT ${CURRENT_EPSONSHA1} STREQUAL ${ESPONSHA1})
     HTTPHEADER "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
     ${CMAKE_CURRENT_BINARY_DIR}/${EPSONFILENAME}
     SHOW_PROGRESS
+    LOG DOWNLOAD_LOG
   )
+  message(" Download-Log: ${DOWNLOAD_LOG} ")
 endif()
 
 


### PR DESCRIPTION
Running `cmake . -B build` should download the epsonscan2 source files, but it just creates a empty file with the name `epsonscan2-6.7.43.0-1.src.tar.gz` inside the build folder.

The problem is that Epson is checking the user agent to verify that a "real" user is requesting a download.

This command without a user agent returns a `403 Forbidden` error.
```
wget https://support.epson.net/linux/src/scanner/epsonscan2/epsonscan2-6.7.43.0-1.src.tar.gz
```

This command containing a user agent downloads the file as expected.
```
wget --user-agent="Mozilla/5.0" https://support.epson.net/linux/src/scanner/epsonscan2/epsonscan2-6.7.43.0-1.src.tar.gz
```

I added the user agent header to the download command and with this modification the download is working again. Without this change the user agent defaults to the curl user agent (e.g `curl/7.81.0`), which probably all get blocked by Epson.